### PR TITLE
Don't rewrite Content-type header in all HTTP requests

### DIFF
--- a/www/src/app/utils/http.interceptor.ts
+++ b/www/src/app/utils/http.interceptor.ts
@@ -27,7 +27,6 @@ import 'rxjs/add/observable/throw';
 @Injectable()
 export class HttpInterceptor extends Http {
     private currentUser: Object;
-    private headers: Headers = new Headers({ 'Content-Type': 'application/json' });
     private configPath: string = environment.configPath;
     private prefixUrl: string;
     private api: Object = {};
@@ -53,18 +52,21 @@ export class HttpInterceptor extends Http {
         this.currentUser = this.getCurrentUser();
 
         if (this.currentUser !== null) {
-            this.headers.set('Authorization', this.currentUser['session_id']);
+            url.headers.set('Authorization', this.currentUser['session_id']);
         }
 
-        url.headers = this.headers;
-
-        if (!options) {
-            url.headers = this.headers;
-            return super.request(url).catch(this.catchErrors());
+        if (url.headers.has('specific-content-type')) {
+            url.headers.delete('specific-content-type')
+        } else {
+            url.headers.set('Content-Type', 'application/json')
         }
-
+        
         // Call the original Http
-        return super.request(url, options).catch(this.catchErrors());
+        if (!options) {
+            return super.request(url).catch(this.catchErrors());
+        } else {
+            return super.request(url, options).catch(this.catchErrors());
+        }
     }
 
     private catchErrors() {


### PR DESCRIPTION
HttpInterceptor currently rewrites headers in all requests and sets
Content-Type to application/json. However, there are usecases when the
application needs to pass its own headers or keep the different
Content-type.

This commit changes HttpInterceptor to keep the original headers,
add what it needs (authentication) and if not set 'specific-content-type'
header, it sets the Content-Type to application/json.